### PR TITLE
Increase composer/semver dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": "^7.1",
 		"contao/core-bundle": "~4.5",
 		"bugbuster/contao-botdetection-bundle":">=0.2.1,<2",
-		"composer/semver": "^1.0",
+		"composer/semver": "^1.0 || ^2.0 || ^3.0",
 		"jean85/pretty-package-versions": "^1.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
The `\Composer\Semver\Semver::satisfies` hasn't changed in newer versions so it is safe to allow to install newer versions, which makes it easer to install this extension in current versions of Contao.